### PR TITLE
Add Contact Page to FrontendStructure so that it appears in the themes "Page Selector Pop-up"

### DIFF
--- a/lib/backend/design/FrontendStructure.php
+++ b/lib/backend/design/FrontendStructure.php
@@ -215,6 +215,15 @@ class FrontendStructure
     ];
 
     private static $pages = [
+        'contact' => [
+            'action' => '',
+            'name' => 'contact',
+            'page_name' => 'contact',
+            'title' => TEXT_CONTACT,
+            'type' => 'home',
+            'group' => 'informations',
+            'settings' => true,
+        ],        
         'home' => [
             'action' => '',
             'name' => 'home',


### PR DESCRIPTION
Using the theme editor, it is impossible to select the "contact" page from the pop-up page list as it is missing.   

This fix adds the "contact" page to the pop-up list under the "informations" page group allowing the user to toggle off the google captcha widget from this screen