### PR TITLE
do a shallow clone

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ INSTALLATION
 You can then install this project using the following command from directory (e.g. `oscommerce`):
 
 ~~~
-git clone https://github.com/osCommerce/osCommerce-V4.git ./ 
+git clone https://github.com/osCommerce/osCommerce-V4.git ./ --depth 1
 ~~~
 
 Make sure your web user has write permissions to the following directories:


### PR DESCRIPTION
makes cloning significantly faster, and reduce the folder size from ~890MB to ~850MB

developers who actually want a full history will ofc know to remove --depth themselves.